### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
         - provider: pypi
           user: carlodef
           password:
-            YOUR_PASSWORD_HERE
+            secure: iSiaNFmj0u6mnRy5x6H850OxxkFTthF8O8OlJCuB/tksL5RdOC2ODbbSsl6S88UMyrTkgyZYR8z8k76zRsBrZzd8pvk29MQ3aBYsp0/94JZFCpbC6hsYvMlk/amlfLJhrclrh5RunpSik7LuW3mobQzUvvCYPH6zu21uKJNshqD9La5rhJg2PB2k+L5wUtikof9qvrQ0TxAE5x13vTThZh/tOIpLt+hSJ/yaLZpHMd4htReIcczEVIJQWMH4yIowJOJNyAeDR6b0fGxjiVirmr1EztFKul3a7tRfTs/lXhTYKLA/0rnBP+/AKyk1cQerNcMze9jvU3LhaWEMe+1heczbBM41AwJghXWK6nY4TjBQYh3QAh0Rnx60S+KhQKms/iD0TVBwoMX7udJuXKNeBpYgmXFnpi2bOYFkR9vVbGsdUY7hTQRG/ujGEeDZ6LcFzDpoXPaVTY1TghZAij/2Y3JvbTuNhnjZDAieycYVJAy8Tt9yrk3uGFlGh1BCouP559cTxLLjGRG1fxYrDGTTlhsfP6hMgwxVcBGvA6Xi7bbdtbwuamqUHBGQBf7PinagJ9mbGJ/C2y1OROGyLhkoDq7xYT/xihKpJ99YZPV+9MImYjRdRUvYW5H56aRfTZcRtcN9iVJ6djq3UNbeywjkprmqvKydkab70fBul0RfW7c=
           distributions: sdist
           on:
             tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+os: linux
+dist: xenial
+language: python
+python: 3.7
+
+install: pip install -e ".[test]"
+script: pytest
+
+jobs:
+  include:
+    - stage: test
+      name: "Python sdist installation"
+      install: skip
+      script:
+        - python setup.py sdist
+        - pip install dist/*.tar.gz
+    - stage: test
+    - stage: test
+      python: 2.7
+
+    - stage: deploy
+      if: tag IS present AND repo = cmla/ransac
+      install: skip
+      script: skip
+      deploy:
+        - provider: pypi
+          user: carlodef
+          password:
+            YOUR_PASSWORD_HERE
+          distributions: sdist
+          on:
+            tags: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # RANSAC
 
+[![Build Status](https://travis-ci.com/cmla/ransac.svg?branch=dev)](https://travis-ci.com/cmla/ransac)
+[![PyPI version](https://img.shields.io/pypi/v/ransac)](https://pypi.org/project/ransac)
+
 Python wrapper around Enric Meinhardt's C implementation of RANSAC distributed
 in [imscript](https://github.com/mnhrdt/imscript).
 
@@ -13,7 +16,8 @@ The `ransac` Python package can be installed from PyPI with
 Alternatively, it can be installed from sources in editable mode with
 
     git clone https://github.com/cmla/ransac
-    pip install -e ransac
+    cd ransac
+    pip install -e .
 
 
 ## Usage

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ class CustomBuildPy(build_py.build_py, object):
 
 requirements = ['numpy']
 
+extras_require = {'test': ['pytest']}
 
 setup(name="ransac",
       version="1.0a5",
@@ -46,5 +47,6 @@ setup(name="ransac",
       author_email="carlo.de-franchis@ens-cachan.fr",
       py_modules=["ransac"],
       install_requires=requirements,
+      extras_require=extras_require,
       cmdclass={'develop': CustomDevelop,
                 'build_py': CustomBuildPy})

--- a/tests/test_ransac.py
+++ b/tests/test_ransac.py
@@ -1,7 +1,8 @@
 import numpy as np
 import ransac
 
-matches = np.loadtxt("tests/data/matches.txt")
-inliers, F = ransac.find_fundamental_matrix(matches)
+def test_ransac():
+    matches = np.loadtxt("tests/data/matches.txt")
+    inliers, F = ransac.find_fundamental_matrix(matches)
 
-np.testing.assert_allclose(F, np.loadtxt("tests/data/F.txt"))
+    np.testing.assert_allclose(F, np.loadtxt("tests/data/F.txt"), atol=1e-5)


### PR DESCRIPTION
This PR adds Travis CI to run tests and deploy to PyPI.

Travis may need to be activated on this repo before merging.

I had to increase the `atol` of `np.testing.assert_allclose` from `0` to `1e-5` due to failing tests on the Travis VM. They were passing fine locally, but not on Travis (see failing build logs [here](https://travis-ci.com/glostis/ransac/jobs/240424785)). I'm not 100% comfortable with `atol` and `rtol` so maybe the change I made was not the best one?