### PR TITLE
makefile: disable avx512 instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS ?=   -march=native -O3
+CFLAGS ?=   -march=native -O3 -mno-avx512f
 
 # The following conditional statement appends "-std=gnu99" to CFLAGS when the
 # compiler does not define __STDC_VERSION__.  The idea is that many older


### PR DESCRIPTION
On high-end skylake CPUs, march=native is skylake-avx512 and enables a series of avx512 instructions, changing the behaviour of the algorithm for some reason:

```
>>> inliers, F = ransac.find_fundamental_matrix(matches)

FAIL("python"): No convergence in 30 SVDCMP iterations

fish: 'python' terminated by signal SIGSEGV (Address boundary error)
```

This fix disables the avx512 instructions to avoid the issue.